### PR TITLE
Fixed bug that occured when languages had some translations missing

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -364,9 +364,7 @@ function getObjects(data, keys) {
       }
       
       if (keys[j] != "identifierIos" && keys[j] != "identifierAndroid") {
-        if (cellData != "") {
-          object["texts"].push(cellData);
-        }
+        object["texts"].push(cellData);
       } else {
         object[keys[j]] = cellData;
       }


### PR DESCRIPTION
If a language in an earlier column had strings missing, that language would not be exported.
Instead the next language would contain any non missing strings from the first language.

For example:

| Polish text  | German text |
| ------------- | ------------- |
|   | Some German 1  |
|   | Some German 2 |
|   | Some German 3 |
| Some Polish  | Some German 4  |

In this instance, when exported, the Polish would not be exported and the German would be exported as:

```
<string name="key1">Some German 1</string>
<string name="key2">Some German 2</string>
<string name="key3">Some German 3</string>
<string name="key4">Some Polish</string>
```

I think this is because your 2D array is getting misaligned.
```
if (cellData != "") {
  object["texts"].push(cellData);
}
```

By not pushing anything, the next column is misaligned. If we push empty string instead, then everything is aligned. Any text that has not been translated is not included in the export because it is caught here:

```
function makeAndroidString(object, textIndex, options) {

    ...

    if (text == undefined || text == "") {
      continue;
    }
```

I don't develop for iOS, and haven't tested how that is exported. But this PR fixes the exporting for Android.

Signed-off-by: Jamie Adkins <jamieadkins95@gmail.com>